### PR TITLE
Update gs

### DIFF
--- a/ghostscript/files/gs
+++ b/ghostscript/files/gs
@@ -1,2 +1,2 @@
 #!/bin/sh
-GS_LIB=/opt/share/ghostscript/9.10/Resource exec /opt/bin/gs.orig "$@"
+GS_LIB=/opt/share/ghostscript/9.16/Resource exec /opt/bin/gs.orig "$@"


### PR DESCRIPTION
changed:
GS_LIB=/opt/share/ghostscript/9.10/Resource exec /opt/bin/gs.orig "$@"
to:
GS_LIB=/opt/share/ghostscript/9.16/Resource exec /opt/bin/gs.orig "$@"

due to Unrecoverable error: execstackoverflow in .findfont  #169
